### PR TITLE
Make executable, add shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ It is working regardless the Keras backend.
 
  1. Run one iteration of simple CNN on MNIST data with `example/mnist_cnn_one_iteration.py` script. It will produce files with architecture `example/my_nn_arch.json` and weights in HDF5 format `example/my_nn_weights.h5`.
  2. Dump network to plain text file `python dump_to_simple_cpp.py -a example/my_nn_arch.json -w example/my_nn_weights.h5 -o example/dumped.nnet`.
- 3. Compile example `g++ keras_model.cc example_main.cc` - see code in `example_main.cc`.
+ 3. Compile example `g++ -std=c++11 keras_model.cc example_main.cc` - see code in `example_main.cc`.
  4. Run binary `./a.out` - you shoul get the same output as in step one from Keras.

--- a/dump_to_simple_cpp.py
+++ b/dump_to_simple_cpp.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import numpy as np
 np.random.seed(1337)
 from keras.models import Sequential, model_from_json


### PR DESCRIPTION
Adds shebang and changes the file mode so that the file is executable. This allows for tab-complete for the parameters -a, -w, -o
